### PR TITLE
Update Projeqtor to last available version (9.5.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This docker image provides a [Projeqtor](https://www.projeqtor.org) container wi
 
 This image is based on `php:7.4-apache`
 
-Version of Projeqtor in this image is currently **9.4.2**
+Version of Projeqtor in this image is currently **9.5.4**
 
 ## Exposed ports :
 


### PR DESCRIPTION
Hi,

I forked your repo, updated Projeqtor tar file to last available (9.5.4) and proceeded with updating my stack.

Worked like a charm.

Attached to this pull request are the commits to get last version running. Nothing fancy.